### PR TITLE
workaround for "I can't find file `larm1200'" on fedora 36

### DIFF
--- a/latex-math.lua
+++ b/latex-math.lua
@@ -12,7 +12,7 @@ function NewLatexRender()
             \usepackage{amsmath}
             \usepackage{amsfonts}
             \usepackage{amssymb}
-            \usepackage[T1,T2A]{fontenc}
+            \usepackage[T2A,T1]{fontenc}
             \usepackage{colordvi}
             \usepackage[active,tightpage]{preview}
         ]],


### PR DESCRIPTION
seems no larm font in texlive package on fedora 36, this is a simple workaround